### PR TITLE
Add user's ethereum public address to local storage

### DIFF
--- a/src/store/AuthContext.js
+++ b/src/store/AuthContext.js
@@ -60,6 +60,9 @@ export const AuthContextProvider = (props) => {
     // Remove group ID from storage
     localStorage.removeItem(GROUP_ID_STORAGE_KEY);
 
+    // Remove Ethereum public address from local storage
+    localStorage.removeItem("ETH_ADDR");
+
     // Clean up local storage
     localStorage.removeItem("isLoggedIn");
 
@@ -108,6 +111,10 @@ export const AuthContextProvider = (props) => {
           // Store user ID in local storage. This will be used to create a unique
           // test group for a user.
           localStorage.setItem("USER_ID", ironcoreInitResult.user.id);
+
+          // Store user public Ethereum address in local storage. This will be used
+          // for making backend API calls.
+          localStorage.setItem("ETH_ADDR", loginDetails.publicAddress);
 
           // Set the default group for the user (find this in Initialization.js)
           const testGroupDetails = await getTestGroupDetails();


### PR DESCRIPTION
Store the user's public ethereum address the Torus generates into local storage. This is necessary to make API calls to protocol backend

## How to test

Start the client applicaiton. Log into the client. Go to your chrome developer console. Click on the application tab. Click on "Local Storage". Verify that in http://localhost:3000 there exists an ETH_ADDR key with a hex value.